### PR TITLE
feat: make Python integration optional via a Cargo feature.

### DIFF
--- a/pacbot_rs/Cargo.toml
+++ b/pacbot_rs/Cargo.toml
@@ -8,22 +8,26 @@ edition = "2021"
 name = "pacbot_rs"
 crate-type = ["lib", "cdylib"]
 
+[features]
+default = ["python"]
+python = ["dep:pyo3", "dep:numpy", "dep:serde-pyobject"]
+
 [dependencies]
 array-init = "2.1.0"
 arrayvec = "0.7.4"
 itertools = "0.14.0"
 ndarray = "0.15.6"
 num_enum = "0.7.1"
-numpy = { version = "0.22.0", features = ["gil-refs"] }
+numpy = { version = "0.22.0", features = ["gil-refs"], optional = true }
 ordered-float = "4.1.1"
 phf = "0.11.2"
-pyo3 = { version = "0.22.6", features = ["gil-refs", "py-clone"] }
+pyo3 = { version = "0.22.6", features = ["gil-refs", "py-clone"], optional = true }
 rand = "0.8.5"
 rand_distr = "0.4.3"
 static_assertions = "1.1.0"
 serde = "1.0.217"
 serde_json = "1.0.134"
-serde-pyobject = "0.4.0"
+serde-pyobject = { version = "0.4.0", optional = true }
 
 candle-core = { version = "0.8.1" }
 candle-nn = { version = "0.8.1" }

--- a/pacbot_rs/src/lib.rs
+++ b/pacbot_rs/src/lib.rs
@@ -3,13 +3,15 @@ pub mod candle_qnet;
 pub mod env;
 pub mod grid;
 // pub mod mcts;
-
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+#[cfg(feature = "python")]
 use env::{PacmanGym, PacmanGymConfiguration};
 // use mcts::MCTSContext;
 
 /// A Python module containing Rust implementations of the PacBot environment.
+#[cfg(feature = "python")]
 #[pymodule]
 fn pacbot_rs(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PacmanGymConfiguration>()?;


### PR DESCRIPTION
Removes the need for python to be installed when using pacbot-rl as a inference library. Simply add `default-features=false` in the cargo.toml when using it for inference.